### PR TITLE
Remove bug where nbColumn equal zero0

### DIFF
--- a/src/dashboard.service.js
+++ b/src/dashboard.service.js
@@ -136,8 +136,8 @@
                         instance.columnsWidth = (100 / options.columns) + '%';
                     }
                 }
-                options.columns = numberOfColumnPossible;
-
+                // If numberOfColumnPossible === 0 then 1 is minimim number of possible column
+                options.columns = (numberOfColumnPossible ? numberOfColumnPossible : 1);
                 //
                 // Dispatch component in new grid layout.
                 //


### PR DESCRIPTION
If screen width is less than component max Width then dashboard was
defining nuzmber of column to zero and saving position differently
as with one column.
If zero column, we make it one with width 100%.
