### PR TITLE
Call component(s) when updating its sorting state is necessary

### DIFF
--- a/src/dashboard.component.directive.html
+++ b/src/dashboard.component.directive.html
@@ -1,4 +1,4 @@
-<div id="component.id" class="dashboard-component">
+<div id="{{component.id}}" class="dashboard-component">
     <div
         class="default"
         ng-include="component.states.default.template"

--- a/src/dashboard.component.directive.js
+++ b/src/dashboard.component.directive.js
@@ -25,6 +25,11 @@
 
                     if (scope.component.states.default && scope.component.states.default.controller) {
                         scope.component.states.default.controller();
+
+                        // update state 'isSorting' for the component
+                        if(scope.component.states.default.refreshStateSorting) {
+                            scope.component.states.default.refreshStateSorting(scope.dashboard.isStateSorting);
+                        }
                     }
 
                     scope.openExtended = function(event) {

--- a/src/dashboard.service.js
+++ b/src/dashboard.service.js
@@ -343,6 +343,13 @@
                     instance.sortable.forEach(function(sort) {
                         sort.option('disabled', !instance.isStateSorting);
                     });
+
+                    // update 'isSorting' state of all components
+                    instance.components.forEach(function(component) {
+                        if(component.states.default.refreshStateSorting) {
+                            component.states.default.refreshStateSorting(instance.isStateSorting);
+                        }
+                    });
                 }
             }
 


### PR DESCRIPTION
(when re-organizing a component in the dashboard, the corresponding column 'sortable' arrays are resized, and because of ng-repeat array array watcher, the digest loop is called. The component needs to handle the display of the 'draggable' layer, and the dashboard needs to call the component to do so)
