### PR TITLE
Issue using Sortable.js directly because of Angular comments for ng-r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 bower_components
 build_docs
 .tmp
+.idea
 src/dashboard.styles.css
 build
 dist

--- a/bower.json
+++ b/bower.json
@@ -24,13 +24,14 @@
   "dependencies": {
     "angular-animate": "~1.5.5",
     "jquery": "~2.1.4",
-    "Sortable": "~1.4.2",
+    "Sortable": "~1.5.1",
     "angular": "~1.5.5",
     "angular-bootstrap": "~0.13.3",
     "bootstrap": "~3.3.5",
     "google-code-prettify": "~1.0.4",
     "Materialize": "materialize#~0.97.3",
-    "angular-mocks": "=1.5.5"
+    "angular-mocks": "=1.5.5",
+    "angular-legacy-sortable": "https://github.com/SortableJS/angular-legacy-sortablejs.git"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.5",

--- a/bower_angular_dashboard/bower.json
+++ b/bower_angular_dashboard/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "bower-angular-dashboard",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "homepage": "https://github.com/fluanceit/bower-angular-dashboard",
     "description": "Distribution of dashboard interface for angularjs (1.x) applications.",
     "main": [

--- a/demos/simple/index.html
+++ b/demos/simple/index.html
@@ -30,6 +30,7 @@
     </div>
     <script src="/bower_components/jquery/dist/jquery.min.js"></script>
     <script src="/bower_components/Sortable/Sortable.min.js"></script>
+    <script src="/bower_components/angular-legacy-sortable/angular-legacy-sortable.js"></script>
     <script src="/bower_components/angular/angular.js"></script>
 
     <script src="/dist/angular-dashboard-fluance.js"></script>

--- a/src/dashboard.directive.html
+++ b/src/dashboard.directive.html
@@ -1,24 +1,24 @@
 <div id="dashboard-{{ id }}"
-    class="dashboard-container"
-    ng-style="{ 'width': dashboard.options.width }">
-    <div
-        id="column{{$index+0}}"
-        class="dashboard-column"
-        ng-class="{
-            'placeholder' : dashboard.isStateSorting,
-            'shake-effect': dashboard.isStateSorting
-        }"
-        ng-repeat="column in dashboard.grid"
-        ng-style="{ 'max-width': dashboard.columnsWidth, 'width': dashboard.columnsWidth }">
-
+     class="dashboard-container"
+     ng-style="{ 'width': dashboard.options.width }">
+    <div ng-repeat="column in dashboard.grid">
         <div
-            class="component"
-            ng-repeat="component in column">
-            <display-component
-                component="component"
-                dashboard="dashboard"></display-component>
+            id="column{{$index+0}}"
+            class="dashboard-column"
+            ng-class="{
+                'placeholder' : dashboard.isStateSorting,
+                'shake-effect': dashboard.isStateSorting
+            }"
+            ng-sortable="sortableConfig"
+            ng-style="{ 'max-width': dashboard.columnsWidth, 'width': dashboard.columnsWidth }">
+            <div
+                class="component"
+                ng-repeat="component in column">
+                <display-component
+                    component="component"
+                    dashboard="dashboard"></display-component>
+            </div>
         </div>
-
     </div>
     <div class="clearfix"></div>
 </div>

--- a/src/dashboard.directive.js
+++ b/src/dashboard.directive.js
@@ -56,6 +56,33 @@
                             }, 150);
                         }
                     }, true);
+
+                    // Sortable configuration
+                    scope.sortableConfig = {
+                        group: {
+                            name: scope.dashboard.id,
+                            pull: function(to, from, dragEl, evt) {
+                                if(evt.type === 'dragstart') {
+                                    return false;
+                                }
+                                return true;
+                            }
+                        },
+                        draggable: '.component',
+                        disabled: scope.dashboard.isStateSorting, // No databinding here, need to be updated
+                        handle: '.sortable-handle',
+                        scroll: true,
+                        scrollSensitivity: 30, // px, how near the mouse must be to an edge to start scrolling.
+                        scrollSpeed: 10, // px
+                        onAdd: function(evt) {
+                            // Event triggered when add in column
+                            scope.dashboard.sortAllComponents(evt);
+                        },
+                        onUpdate: function(evt) {
+                            // event triggered when column is changed
+                            scope.dashboard.sortAllComponents(evt);
+                        }
+                    }
                 }]
             };
         }]);

--- a/src/dashboard.module.js
+++ b/src/dashboard.module.js
@@ -11,5 +11,5 @@
      * Main module to display angular dashboard fluance.
      *
      **/
-    angular.module('dashboard', []);
+    angular.module('dashboard', ['ng-sortable']);
 })();

--- a/src/dashboard.service.js
+++ b/src/dashboard.service.js
@@ -48,7 +48,7 @@
                     'width': 'auto',
                     // Number of columns in dashboard
                     'columns': '2',
-                    // Min widht of columns.
+                    // Min width of columns.
                     'columnsMinWidth': null,
                     // Enable/disable sorting
                     'sortable': true,
@@ -68,15 +68,16 @@
                 enableExtended: enableExtended,
                 disableExtended: disableExtended,
                 refresh: refresh,
-                toggleSortable: toggleSortable
+                toggleSortable: toggleSortable,
+                sortAllComponents: sortAllComponents
             };
 
             var instance = DEFAULT_DASHBOARD;
-
             var lastNumberColumns, maxAllowColumns;
 
             return instance;
 
+            // ---------------------------------------------------------------------------
 
             /**
              * Add a component in array
@@ -147,7 +148,6 @@
                     instance.grid[i] = [];
                 }
 
-                instance.sortable = null;
                 // For each component, we define its position and inject it in our grid object.
                 // Grid is displayed in DOM by dashboard.directive.js
                 instance.components.forEach(function(component) {
@@ -308,82 +308,30 @@
             function sortAllComponents(evt) {
                 var oldColumn,
                     newColumn,
-                    component,
                     nbColumn;
 
                 // Identify columns
-                oldColumn = evt.from.id.replace('column', '');
-                newColumn = evt.to.id.replace('column', '');
+                oldColumn = evt.originalEvent.from.id.replace('column', '');
+                newColumn = evt.originalEvent.to.id.replace('column', '');
 
-                // Get component as tmp
-                component = instance.grid[oldColumn][evt.oldIndex];
+                // -- update the component position in the current grid configuration (total number of columns) --
 
-                // sort component only if it is found:
-                // - update the component position in the current grid configuration (total number of columns)
-                if(component) {
-                    // Remove component from dragged location (old column)
-                    instance.grid[oldColumn].splice(evt.oldIndex, 1);
+                // Get total number of columns in the grid
+                nbColumn = instance.options['columns'];
 
-                    // Get total number of columns in the grid
-                    nbColumn = instance.options['columns'];
+                // Update old (FROM) position indexes:
+                // - component was removed from array, update the position of all components in this array
+                instance.grid[oldColumn].forEach(function (component, index) {
+                    // column remains the same; update only the component position
+                    component.positions[nbColumn].position = parseInt(index);
+                });
 
-                    // Update component position to dropped column (new)
-                    component.positions[nbColumn].column = newColumn;
-
-                    // Add component to dropped location (new column)
-                    instance.grid[newColumn].splice(evt.newIndex, 0, component);
-
-                    // Update old position indexes:
-                    // - component was removed from array, update the position of all components in this array
-                    instance.grid[oldColumn].forEach(function (component, index) {
-                        // column remains the same; update only the component position
-                        //component.positions[nbColumn].column = parseInt(oldColumn);
-                        component.positions[nbColumn].position = parseInt(index);
-                    });
-
-                    // Update new position index:
-                    // - component was added into array, update the position of all components in this array
-                    instance.grid[newColumn].forEach(function (component, index) {
-                        // column remains the same; update only the component position
-                        //component.positions[nbColumn].column = parseInt(newColumn);
-                        component.positions[nbColumn].position = parseInt(index);
-                    });
-                }
-            }
-
-            /**
-             * Apply Sortable to HTML and make it draggable/droppable
-             */
-            function makeItSortable() {
-
-                // If columns have already been initialize
-                if (!instance.sortable) {
-                    instance.sortable = [];
-
-                    // apply sortable on each column.
-                    for (var i = 0; i < instance.grid.length; i++) {
-
-                        instance.sortable.push(
-                            Sortable.create(document.getElementById('column' + i), {
-                                group: instance.id,
-                                draggable: '.component',
-                                disabled: !instance.isStateSorting, // No databinding here, need to be updated
-                                handle: '.sortable-handle',
-                                scroll: true,
-                                scrollSensitivity: 30, // px, how near the mouse must be to an edge to start scrolling.
-                                scrollSpeed: 10, // px
-                                onAdd: function(evt) {
-                                    // Event triggered when add in column
-                                    sortAllComponents(evt);
-                                },
-                                onUpdate: function(evt) {
-                                    // event triggered when column is changed
-                                    sortAllComponents(evt);
-                                }
-                            })
-                        );
-                    }
-                }
+                // Update new (TO) position index:
+                // - component was added into array, update the position of all components in this array
+                instance.grid[newColumn].forEach(function (component, index) {
+                    component.positions[nbColumn].column = parseInt(newColumn);
+                    component.positions[nbColumn].position = parseInt(index);
+                });
             }
 
             /**
@@ -394,13 +342,8 @@
                 if (!instance.options['sortable']) {
                     console.log('This dashboard does not allow sorting (see options configuration).');
                 } else {
-                    makeItSortable();
                     // Toggle sorting state
                     instance.isStateSorting = !instance.isStateSorting;
-                    // Change disable option for each column
-                    instance.sortable.forEach(function(sort) {
-                        sort.option('disabled', !instance.isStateSorting);
-                    });
 
                     // update 'isSorting' state of all components
                     instance.components.forEach(function(component) {


### PR DESCRIPTION
…epeat/ng-if's and Sortable DOM manipulation:

- use Angular 1.x wrapper (angular-legacy-sortable)
- update Sortable.js version

Issue with component always being cloned instead of moved when using default 'pull' value:
- fix this bug (in Sortable.js) by defining a function for 'pull' config option that returns 'false' on 'dragstart' event, but 'true' for other drag events (eg 'dragmove'), so that element can be dragged and dropped but not cloned.

To declaratively associate every dashboard column with a Sortable instance (like it was done programmatically), declare "ng-sortable" inside the "ng-repeat" for columns. In this way, each column will register event listeners for drag events, and a component can be dragged and dropped to an empty column (column without components, but with a placeholder and min-height)

Export sortAllComponents() from service:
- let dashboard directive call sortAllComponents() on callbacks for drag events to update the positions of components in the modified columns
- modify function to only update the positions of components in the source (oldColumn) and target (newColumn) columns

Update patch version