### PR TITLE
Add Angular 1.x Sortable.js wrapper dependency

### DIFF
--- a/bower_angular_dashboard/bower.json
+++ b/bower_angular_dashboard/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "bower-angular-dashboard",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "homepage": "https://github.com/fluanceit/bower-angular-dashboard",
     "description": "Distribution of dashboard interface for angularjs (1.x) applications.",
     "main": [
@@ -23,6 +23,7 @@
     "dependencies": {
         "jquery": "~2.1.4",
         "Sortable": "~1.5.1",
-        "angular": "~1.5.5"
+        "angular": "~1.5.5",
+        "angular-legacy-sortable": "https://github.com/SortableJS/angular-legacy-sortablejs.git"
     }
 }


### PR DESCRIPTION
- add Angular 1.x Sortable.js wrapper dependency (angular-legacy-sortable, from Github. Not published in Bower yet) to bower.json of Distribution repository
- update patch version of distribution