### PR TITLE
Update Sortable.js version to 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.12'
+- '6'
 install:
 - npm install
 - bower install

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "angular-animate": "~1.5.5",
     "jquery": "~2.1.4",
-    "Sortable": "~1.5.1",
+    "Sortable": "~1.6.0",
     "angular": "~1.5.5",
     "angular-bootstrap": "~0.13.3",
     "bootstrap": "~3.3.5",


### PR DESCRIPTION
Drag-n-drop stopped working in Chrome#62. Fixed in version >=1.6.0

see:
https://github.com/RubaXa/Sortable/issues/1182
https://github.com/RubaXa/Sortable/issues/1199